### PR TITLE
Edit messages for sf-ized schema commands

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -2,7 +2,7 @@
   {
     "command": "sobject:describe",
     "plugin": "@salesforce/plugin-schema",
-    "flags": ["api-version", "json", "loglevel", "sobject", "target-org", "tooling-api"],
+    "flags": ["api-version", "json", "loglevel", "sobject", "target-org", "use-tooling-api"],
     "alias": ["force:schema:sobject:describe"]
   },
   {

--- a/messages/describe.md
+++ b/messages/describe.md
@@ -14,9 +14,9 @@ This command displays metadata for Salesforce objects by default. Use the --use-
 
   <%= config.bin %> <%= command.id %> --sobject Account
 
-- Display the metadata of the "MyObject\_\_c" custom object in the org with alias "my-scratch-org":
+- Display the metadata of the "MyObject__c" custom object in the org with alias "my-scratch-org":
 
-  <%= config.bin %> <%= command.id %> --sobject MyObject\_\_c --target-org my-scratch-org
+  <%= config.bin %> <%= command.id %> --sobject MyObject__c --target-org my-scratch-org
 
 - Display the metadata of the ApexCodeCoverage Tooling API object in your default org:
 

--- a/messages/describe.md
+++ b/messages/describe.md
@@ -1,21 +1,31 @@
 # summary
 
-Displays the metadata for a standard or custom object.
+Display the metadata for a standard or custom object or a Tooling API object.
 
 # description
 
-You must specify a Salesforce org to use, either with the --target-org flag or by setting your default org with the `target-org` configuration variable.
+The metadata is displayed in JSON format. See this topic for a description of each property: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_calls_describesobjects_describesobjectresult.htm.
+
+This command displays metadata for Salesforce objects by default. Use the --use-tooling-api flag to view metadata for a Tooling API object.
 
 # examples
 
-- Get the metadata of the "Account" standard object:
+- Display the metadata of the "Account" standard object in your default org:
 
-  <%= config.bin %> <%= command.id %> --target-org my-org --sobject Account
+  <%= config.bin %> <%= command.id %> --sobject Account
+
+- Display the metadata of the "MyObject\_\_c" custom object in the org with alias "my-scratch-org":
+
+  <%= config.bin %> <%= command.id %> --sobject MyObject\_\_c --target-org my-scratch-org
+
+- Display the metadata of the ApexCodeCoverage Tooling API object in your default org:
+
+  <%= config.bin %> <%= command.id %> --sobject ApexCodeCoverage --use-tooling-api
 
 # flags.sobject.summary
 
-The API name of the object to describe.
+API name of the object to describe.
 
 # flags.tooling-api.summary
 
-Execute the request with the Tooling API.
+Use Tooling API to display metadata for Tooling API objects.

--- a/messages/list.md
+++ b/messages/list.md
@@ -4,7 +4,7 @@ List all Salesforce objects of a specified category.
 
 # description
 
-You can list the standard objects, custom objects, or all. List includes only Salesforce objects, not Tooling API objects.
+You can list the standard objects, custom objects, or all. The lists include only Salesforce objects, not Tooling API objects.
 
 # examples
 

--- a/messages/list.md
+++ b/messages/list.md
@@ -4,21 +4,21 @@ List all Salesforce objects of a specified category.
 
 # description
 
-You must specify a Salesforce org to use, either with the --target-org flag or by setting your default org with the `target-org` configuration variable.
+You can list the standard objects, custom objects, or all. List includes only Salesforce objects, not Tooling API objects.
 
 # examples
 
-- List all objects:
+- List all objects in your default org:
 
-  <%= config.bin %> <%= command.id %> --target-org my-org --sobject all
+  <%= config.bin %> <%= command.id %> --sobject all
 
-- Only list custom objects:
+- List only custom objects in the org with alias "my-scratch-org":
 
-  <%= config.bin %> <%= command.id %> --target-org my-org --sobject custom
+  <%= config.bin %> <%= command.id %> --sobject custom --target-org my-scratch-org
 
 # flags.sobject.summary
 
-Type of objects to list.
+Category of objects to list.
 
 # noTypeFound
 

--- a/src/commands/sobject/describe.ts
+++ b/src/commands/sobject/describe.ts
@@ -34,7 +34,7 @@ export class SObjectDescribe extends SfCommand<DescribeSObjectResult> {
       summary: messages.getMessage('flags.sobject.summary'),
       aliases: ['sobjecttype'],
     }),
-    'tooling-api': Flags.boolean({
+    'use-tooling-api': Flags.boolean({
       summary: messages.getMessage('flags.tooling-api.summary'),
       aliases: ['usetoolingapi', 't'],
     }),
@@ -44,7 +44,7 @@ export class SObjectDescribe extends SfCommand<DescribeSObjectResult> {
     const { flags } = await this.parse(SObjectDescribe);
     const conn = flags['target-org'].getConnection(flags['api-version']);
 
-    const description = flags['tooling-api']
+    const description = flags['use-tooling-api']
       ? await conn.tooling.describe(flags.sobject)
       : await conn.describe(flags.sobject);
 


### PR DESCRIPTION
### What does this PR do?

Edits messages for the two schema commands:  "sobject describe" and "sobject list"

It also changes the name of --tooling-api flag of 'sobject describe' to --use-tooling-api to match the similar flag in the "data record" commands.

### What issues does this PR fix or reference?
@W-12247438@
